### PR TITLE
Fixed bug with multilinestring conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,32 +38,7 @@ select geoc_bd09togcj02(geom) from test_table
 PostgreSQL安装PostGIS扩展
 复制geoc-pg-coordtansform.sql中代码，在数据库执行
 ```
-# Who use/Who star
 
-- 阿里巴巴（digoal,德哥）
-
-- 国信司南（北京）地理信息技术有限公司（本库作者）
-
-- [CTOLib码库](https://javascript.ctolib.com/geocompass-pg-coordtransform.html)
-
-- 九天气象（lzuniujp08）
-
-- 深圳普天宜通股份有限公司（ShareQiu1994）
-
-- 中原百科（zhongyuanbaike）
-
-- MonsterBOBO（hanrea）
-
-- nocode（sanford）
-
-
-## Author
-
-👤 **LH  QQ:1016817543**
-
-👤 **Wangsb  QQ:1017218804**
-
-* Github: [@MrSmallLiu](https://github.com/MrSmallLiu)
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,18 +72,6 @@ Contributions, issues and feature requests are welcome!<br />Feel free to check 
 修改src下的文件，使用linux相关命令将文件合并为一个
 
 `find src/ -name "*.sql" | xargs sed 'a\' > geoc-pg-coordtransform.sql`
-## 长期招聘
-- 岗位1：WebGIS开发工程师
-- 岗位2：Node.js后端开发工程师
-- 岗位3：前端开发工程师
-
-GIS专业背景或地图开发经验优先
-
-联系方式：
-
-qq/微信：1016817543
-
-简历投递邮箱：liuhang@geo-compass.com
     
 
 ***

--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@ PostgreSQL安装PostGIS扩展
 复制geoc-pg-coordtansform.sql中代码，在数据库执行
 ```
 
-
-## 🤝 Contributing
-
-Contributions, issues and feature requests are welcome!<br />Feel free to check [issues page](https://github.com/geocompass/pg-coordtransform/issues).
 ## 开发
 修改src下的文件，使用linux相关命令将文件合并为一个
 

--- a/geoc-pg-coordtransform.sql
+++ b/geoc-pg-coordtransform.sql
@@ -189,7 +189,7 @@ BEGIN
 	  	transform_i :=geoc_gcj02tobd09_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE
@@ -564,7 +564,7 @@ BEGIN
 	  	transform_i :=geoc_wgs84tobd09_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE
@@ -728,7 +728,7 @@ BEGIN
 	  	transform_i :=geoc_wgs84togcj02_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE
@@ -929,7 +929,7 @@ BEGIN
 	  	transform_i :=geoc_bd09togcj02_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE
@@ -1100,7 +1100,7 @@ BEGIN
 	  	transform_i :=geoc_bd09towgs84_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/geoc-pg-coordtransform.sql
+++ b/geoc-pg-coordtransform.sql
@@ -364,7 +364,7 @@ BEGIN
 	  	transform_i :=geoc_gcj02towgs84_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/src/geoc_bd09togcj02_multiline.sql
+++ b/src/geoc_bd09togcj02_multiline.sql
@@ -11,7 +11,7 @@ BEGIN
 	  	transform_i :=geoc_bd09togcj02_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/src/geoc_bd09towgs84_multiline.sql
+++ b/src/geoc_bd09towgs84_multiline.sql
@@ -11,7 +11,7 @@ BEGIN
 	  	transform_i :=geoc_bd09towgs84_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/src/geoc_gcj02tobd09_multiline.sql
+++ b/src/geoc_gcj02tobd09_multiline.sql
@@ -11,7 +11,7 @@ BEGIN
 	  	transform_i :=geoc_gcj02tobd09_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/src/geoc_gcj02towgs84_multiline.sql
+++ b/src/geoc_gcj02towgs84_multiline.sql
@@ -11,7 +11,7 @@ BEGIN
 	  	transform_i :=geoc_gcj02towgs84_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/src/geoc_wgs84tobd09_multiline.sql
+++ b/src/geoc_wgs84tobd09_multiline.sql
@@ -11,7 +11,7 @@ BEGIN
 	  	transform_i :=geoc_wgs84tobd09_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE

--- a/src/geoc_wgs84togcj02_multiline.sql
+++ b/src/geoc_wgs84togcj02_multiline.sql
@@ -11,7 +11,7 @@ BEGIN
 	  	transform_i :=geoc_wgs84togcj02_line(i);
 		multiArr := array_append(multiArr, transform_i);
 	end LOOP;
-	return st_multi(ST_Union(multiArr));
+	return st_multi(ST_Collect(multiArr));
 END;
 $BODY$
   LANGUAGE plpgsql VOLATILE


### PR DESCRIPTION
geoc_gcj02towgs84_multiline has a bug, when merging lines you should use ST_Collect instead of ST_Union, using ST_Union will cause the structure of multilinestring to be inconsistent before and after the conversion.